### PR TITLE
Fix rustls crypto provider panic

### DIFF
--- a/src/initialization.rs
+++ b/src/initialization.rs
@@ -9,6 +9,7 @@ use tokio::sync::Semaphore;
 use colored::*;
 use log::LevelFilter;
 use crate::error_handling::InitializationError;
+use rustls::crypto::CryptoProvider;
 
 /// Initializes the logger for the application with the provided configuration.
 pub fn init_logger() -> Result<(), InitializationError> {
@@ -75,4 +76,10 @@ pub async fn init_client() -> Result<Arc<reqwest::Client>, reqwest::Error> {
 /// Initializes the TLD extractor.
 pub fn init_extractor() -> Arc<TldExtractor> {
     Arc::new(TldExtractor::new(TldOption::default()))
+}
+
+/// Installs the default CryptoProvider required by rustls.
+pub fn init_crypto_provider() {
+    // The return value is ignored because reinstalling the provider is harmless
+    let _ = CryptoProvider::install_default();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ fn log_progress(start_time: std::time::Instant, completed_urls: &Arc<AtomicUsize
 #[tokio::main]
 async fn main() -> Result<()> {
     init_logger().context("Failed to initialize logger")?;
+    init_crypto_provider();
 
     let opt = Opt::from_args();
     let file = File::open(&opt.file).context("Failed to open input file")?;


### PR DESCRIPTION
## Summary
- install rustls CryptoProvider during initialization
- call the crypto provider setup from `main`

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*